### PR TITLE
Add df-contracts package implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[polars]
+          pip install pytest pytest-cov ruff black mypy
+      - name: Lint
+        run: |
+          ruff check .
+          black --check .
+      - name: Type check
+        run: mypy
+      - name: Test
+        run: pytest --cov=df_contracts

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+build/
+dist/
+.venv/
+.coverage
+htmlcov/
+.mypy_cache/
+.pytest_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.0
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 df-contracts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # df-contracts
-Zero-ceremony DataFrame contracts: declare required columns, dtypes, nullability,   ranges, enums, uniqueness, regex/length, datetime and cross-column rules.
+Lightweight, Python-first DataFrame contracts (schema + rules) for pandas.
+
+## Install
+```bash
+python -m venv .venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -e .
+```
+
+## Overview
+`df-contracts` helps teams encode schema and data quality expectations for pandas DataFrames.
+Define a contract, validate datasets, and surface actionable reports from Python, the CLI, or pytest.
+
+## Features
+- Declarative column specifications including dtype, nullability, bounds, enums, regex, and more.
+- Row and table level rules with rich reporting and JSON export.
+- Contract inference from real datasets to bootstrap adoption quickly.
+- Typer-powered CLI and pytest plugin for streamlined automation.
+
+## Development
+Install development dependencies and run the test suite:
+
+```bash
+pip install -e .[polars]
+pip install -r requirements-dev.txt  # optional helper if you create one
+pytest
+```

--- a/df_contracts/__init__.py
+++ b/df_contracts/__init__.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from .api import compare, is_breaking_change, validate
+from .inference import infer_contract
+from .report import ValidationReport
+from .schema import ColumnSpec, Contract, RuleSpec, load_contract, save_contract
+from .versioning import compare_contracts
+
+__all__ = [
+    "ColumnSpec",
+    "Contract",
+    "RuleSpec",
+    "ValidationReport",
+    "compare",
+    "compare_contracts",
+    "infer_contract",
+    "is_breaking_change",
+    "load_contract",
+    "save_contract",
+    "validate",
+]

--- a/df_contracts/api.py
+++ b/df_contracts/api.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import time
+from typing import Any, List
+
+import pandas as pd
+import regex
+from pandas.api.types import is_datetime64_any_dtype, is_numeric_dtype
+
+from . import versioning
+from .checks import TABLE_CHECKS
+from .errors import RuleExecutionError
+from .report import ValidationReport
+from .schema import ColumnSpec, Contract, RuleSpec
+from .types import ValidationStats, ViolationDict
+from .utils import ensure_pandas, head_records, is_dtype_compatible, normalize_dtype
+
+
+def validate(
+    df: pd.DataFrame,
+    contract: Contract,
+    *,
+    profile: str = "prod",
+    sample: float | None = None,
+    max_examples: int = 20,
+) -> ValidationReport:
+    frame = ensure_pandas(df).copy()
+    if sample:
+        if not 0 < sample <= 1:
+            raise ValueError("sample must be in (0, 1]")
+        frame = frame.sample(frac=sample, random_state=0)
+    start = time.perf_counter()
+    stats: ValidationStats = {
+        "rows": int(frame.shape[0]),
+        "cols": int(frame.shape[1]),
+        "duration_ms": 0,
+    }
+    violations: List[ViolationDict] = []
+    schema_diffs: list[str] = []
+    ok = True
+    available_columns = set(frame.columns)
+    for column in contract.columns:
+        if column.name not in frame.columns:
+            schema_diffs.append(f"missing column {column.name}")
+            violations.append(
+                _violation(
+                    violation_id=f"column.{column.name}.missing",
+                    level="ERROR",
+                    kind="schema",
+                    columns=[column.name],
+                    summary=f"Column {column.name} missing",
+                    count=frame.shape[0],
+                    examples=[],
+                )
+            )
+            ok = False
+            continue
+        series = frame[column.name]
+        available_columns.discard(column.name)
+        actual_dtype = normalize_dtype(series.dtype)
+        if not is_dtype_compatible(actual_dtype, column.dtype):
+            schema_diffs.append(
+                f"dtype mismatch for {column.name}: expected {column.dtype} got {actual_dtype}"
+            )
+            violations.append(
+                _violation(
+                    violation_id=f"column.{column.name}.dtype",
+                    level="ERROR",
+                    kind="schema",
+                    columns=[column.name],
+                    summary=f"Expected dtype {column.dtype} got {actual_dtype}",
+                    count=frame.shape[0],
+                    examples=[],
+                )
+            )
+            ok = False
+        null_ratio = float(series.isna().mean())
+        if column.nullable is False and null_ratio > 0:
+            violations.append(
+                _violation(
+                    violation_id=f"column.{column.name}.nulls",
+                    level="ERROR",
+                    kind="column",
+                    columns=[column.name],
+                    summary=f"Null ratio {null_ratio:.3f} exceeds allowed 0",
+                    count=int(series.isna().sum()),
+                    examples=_series_examples(series.isna(), series, max_examples),
+                )
+            )
+            ok = False
+        elif isinstance(column.nullable, float) and null_ratio > column.nullable:
+            violations.append(
+                _violation(
+                    violation_id=f"column.{column.name}.nulls",
+                    level="ERROR",
+                    kind="column",
+                    columns=[column.name],
+                    summary=f"Null ratio {null_ratio:.3f} exceeds allowed {column.nullable}",
+                    count=int(series.isna().sum()),
+                    examples=_series_examples(series.isna(), series, max_examples),
+                )
+            )
+            ok = False
+        if column.enum and not column.allow_unknown:
+            allowed = set(column.enum)
+            bad_values = series.dropna().astype(str)
+            mask = ~bad_values.isin(allowed)
+            if mask.any():
+                examples = bad_values[mask].head(max_examples).to_frame(name=column.name)
+                violations.append(
+                    _violation(
+                        violation_id=f"column.{column.name}.enum",
+                        level="ERROR",
+                        kind="column",
+                        columns=[column.name],
+                        summary=f"Found unexpected values {sorted(bad_values[mask].unique())[:5]}",
+                        count=int(mask.sum()),
+                        examples=head_records(examples, limit=max_examples),
+                    )
+                )
+                ok = False
+        if column.regex:
+            pattern = regex.compile(column.regex)
+            str_values = series.dropna().astype(str)
+            mask = ~str_values.apply(pattern.fullmatch)
+            if mask.any():
+                examples = str_values[mask].head(max_examples).to_frame(name=column.name)
+                violations.append(
+                    _violation(
+                        violation_id=f"column.{column.name}.regex",
+                        level="ERROR",
+                        kind="column",
+                        columns=[column.name],
+                        summary="Values do not match required pattern",
+                        count=int(mask.sum()),
+                        examples=head_records(examples, limit=max_examples),
+                    )
+                )
+                ok = False
+        if column.min is not None or column.max is not None:
+            if is_numeric_dtype(series) or _coerce_numeric(series):
+                numeric_series = pd.to_numeric(series, errors="coerce")
+                if column.min is not None:
+                    min_value = float(column.min)
+                    mask = numeric_series < min_value
+                    ok = _check_bounds(
+                        ok,
+                        mask,
+                        column,
+                        "min",
+                        min_value,
+                        numeric_series,
+                        violations,
+                        max_examples,
+                    )
+                if column.max is not None:
+                    max_value = float(column.max)
+                    mask = numeric_series > max_value
+                    ok = _check_bounds(
+                        ok,
+                        mask,
+                        column,
+                        "max",
+                        max_value,
+                        numeric_series,
+                        violations,
+                        max_examples,
+                    )
+            elif _coerce_datetime(series):
+                dt_series = pd.to_datetime(series, errors="coerce")
+                if column.min is not None:
+                    min_value = pd.to_datetime(column.min)
+                    mask = dt_series < min_value
+                    ok = _check_bounds(
+                        ok,
+                        mask,
+                        column,
+                        "min",
+                        min_value,
+                        dt_series,
+                        violations,
+                        max_examples,
+                    )
+                if column.max is not None:
+                    max_value = pd.to_datetime(column.max)
+                    mask = dt_series > max_value
+                    ok = _check_bounds(
+                        ok,
+                        mask,
+                        column,
+                        "max",
+                        max_value,
+                        dt_series,
+                        violations,
+                        max_examples,
+                    )
+        if column.min_length is not None or column.max_length is not None:
+            lengths = series.dropna().astype(str).str.len()
+            if column.min_length is not None:
+                mask = lengths < column.min_length
+                if mask.any():
+                    examples = series.dropna().astype(str)[mask].head(max_examples).to_frame(name=column.name)
+                    violations.append(
+                        _violation(
+                            violation_id=f"column.{column.name}.min_length",
+                            level="ERROR",
+                            kind="column",
+                            columns=[column.name],
+                            summary=f"Length shorter than {column.min_length}",
+                            count=int(mask.sum()),
+                            examples=head_records(examples, limit=max_examples),
+                        )
+                    )
+                    ok = False
+            if column.max_length is not None:
+                mask = lengths > column.max_length
+                if mask.any():
+                    examples = series.dropna().astype(str)[mask].head(max_examples).to_frame(name=column.name)
+                    violations.append(
+                        _violation(
+                            violation_id=f"column.{column.name}.max_length",
+                            level="ERROR",
+                            kind="column",
+                            columns=[column.name],
+                            summary=f"Length exceeds {column.max_length}",
+                            count=int(mask.sum()),
+                            examples=head_records(examples, limit=max_examples),
+                        )
+                    )
+                    ok = False
+        if column.unique is True:
+            mask = series.duplicated(keep=False)
+            if mask.any():
+                duplicates = frame.loc[mask, [column.name]]
+                violations.append(
+                    _violation(
+                        violation_id=f"column.{column.name}.unique",
+                        level="ERROR",
+                        kind="column",
+                        columns=[column.name],
+                        summary="Duplicate values found",
+                        count=int(mask.sum()),
+                        examples=head_records(duplicates, limit=max_examples),
+                    )
+                )
+                ok = False
+    if not contract.allow_extra_columns and available_columns:
+        for extra in sorted(available_columns):
+            schema_diffs.append(f"unexpected column {extra}")
+            violations.append(
+                _violation(
+                    violation_id=f"column.{extra}.unexpected",
+                    level="WARN",
+                    kind="schema",
+                    columns=[extra],
+                    summary="Unexpected column present",
+                    count=frame.shape[0],
+                    examples=[],
+                )
+            )
+    for key in contract.unique_keys:
+        mask = frame.duplicated(subset=key, keep=False)
+        if mask.any():
+            duplicates = frame.loc[mask, key]
+            violations.append(
+                _violation(
+                    violation_id=f"contract.unique.{'+'.join(key)}",
+                    level="ERROR",
+                    kind="table",
+                    columns=list(key),
+                    summary="Composite key is not unique",
+                    count=int(mask.sum()),
+                    examples=head_records(duplicates, limit=max_examples),
+                )
+            )
+            ok = False
+    for rule in contract.rules:
+        if rule.kind == "row" and rule.expr:
+            ok = _apply_row_rule(rule, frame, violations, ok, max_examples)
+        elif rule.kind == "table" and rule.fn_name:
+            ok = _apply_table_rule(rule, frame, violations, ok, max_examples)
+    stats["duration_ms"] = int((time.perf_counter() - start) * 1000)
+    return ValidationReport(ok=ok, stats=stats, violations=violations, schema_diffs=schema_diffs)
+
+
+def _violation(
+    *,
+    violation_id: str,
+    level: str,
+    kind: str,
+    columns: list[str],
+    summary: str,
+    count: int,
+    examples: list[dict[str, Any]],
+) -> ViolationDict:
+    return {
+        "id": violation_id,
+        "level": level,
+        "kind": kind,
+        "columns": columns,
+        "summary": summary,
+        "count": count,
+        "examples": examples,
+    }
+
+
+def _series_examples(mask: pd.Series, series: pd.Series, limit: int) -> list[dict[str, Any]]:
+    failing = series[mask]
+    return head_records(failing.to_frame(series.name or "value"), limit=limit)
+
+
+def _coerce_numeric(series: pd.Series) -> bool:
+    if is_numeric_dtype(series):
+        return True
+    coerced = pd.to_numeric(series, errors="coerce")
+    return coerced.notna().any()
+
+
+def _coerce_datetime(series: pd.Series) -> bool:
+    if is_datetime64_any_dtype(series):
+        return True
+    coerced = pd.to_datetime(series, errors="coerce")
+    return coerced.notna().any()
+
+
+def _check_bounds(
+    ok: bool,
+    mask: pd.Series,
+    column: ColumnSpec,
+    bound: str,
+    value: Any,
+    series: pd.Series,
+    violations: list[ViolationDict],
+    max_examples: int,
+) -> bool:
+    if mask.any():
+        examples = series[mask].head(max_examples).to_frame(name=column.name)
+        violations.append(
+            _violation(
+                violation_id=f"column.{column.name}.{bound}",
+                level="ERROR",
+                kind="column",
+                columns=[column.name],
+                summary=f"Values violate {bound} {value}",
+                count=int(mask.sum()),
+                examples=head_records(examples, limit=max_examples),
+            )
+        )
+        return False
+    return ok
+
+
+def _apply_row_rule(
+    rule: RuleSpec,
+    frame: pd.DataFrame,
+    violations: list[ViolationDict],
+    ok: bool,
+    max_examples: int,
+) -> bool:
+    try:
+        result = frame.eval(rule.expr, engine="python")  # type: ignore[arg-type]
+    except Exception as exc:  # pragma: no cover - defensive
+        raise RuleExecutionError(str(exc)) from exc
+    if result.dtype != bool:
+        result = result.astype(bool)
+    mask = ~result.fillna(False)
+    if mask.any():
+        failing = frame.loc[mask]
+        violations.append(
+            _violation(
+                violation_id=f"rule.{rule.id}",
+                level=rule.level,
+                kind="row",
+                columns=list(failing.columns),
+                summary=rule.message,
+                count=int(mask.sum()),
+                examples=head_records(failing, limit=max_examples),
+            )
+        )
+        if rule.level == "ERROR":
+            ok = False
+    return ok
+
+
+def _apply_table_rule(
+    rule: RuleSpec,
+    frame: pd.DataFrame,
+    violations: list[ViolationDict],
+    ok: bool,
+    max_examples: int,
+) -> bool:
+    fn = TABLE_CHECKS.get(rule.fn_name or "")
+    if not fn:
+        raise RuleExecutionError(f"Unknown table rule: {rule.fn_name}")
+    failing = fn(frame, rule.params)
+    if not failing.empty:
+        violations.append(
+            _violation(
+                violation_id=f"rule.{rule.id}",
+                level=rule.level,
+                kind="table",
+                columns=list(failing.columns),
+                summary=rule.message,
+                count=int(failing.shape[0]),
+                examples=head_records(failing, limit=max_examples),
+            )
+        )
+        if rule.level == "ERROR":
+            ok = False
+    return ok
+
+
+def compare(old: Contract, new: Contract) -> dict[str, Any]:
+    return versioning.compare_contracts(old, new)
+
+
+def is_breaking_change(diff: dict[str, Any]) -> bool:
+    return versioning.is_breaking_change(diff)

--- a/df_contracts/checks.py
+++ b/df_contracts/checks.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+import pandas as pd
+
+
+TableCheck = Callable[[pd.DataFrame, dict[str, object]], pd.DataFrame]
+
+
+def start_le_end(frame: pd.DataFrame, params: dict[str, object]) -> pd.DataFrame:
+    start_col = str(params["start"])
+    end_col = str(params["end"])
+    mask = frame[start_col] > frame[end_col]
+    return frame.loc[mask, [start_col, end_col]]
+
+
+def non_decreasing_by_key(frame: pd.DataFrame, params: dict[str, object]) -> pd.DataFrame:
+    column = str(params["col"])
+    by_cols = [str(col) for col in params.get("by", [])]
+    if not by_cols:
+        diffs = frame[column].diff()
+        mask = diffs < 0
+        return frame.loc[mask, [column]]
+    violations: List[pd.DataFrame] = []
+    for _, group in frame.groupby(by_cols, dropna=False):
+        diffs = group[column].diff()
+        mask = diffs < 0
+        if mask.any():
+            violations.append(group.loc[mask, by_cols + [column]])
+    if not violations:
+        return frame.iloc[0:0]
+    return pd.concat(violations, axis=0)
+
+
+def within_tolerance(frame: pd.DataFrame, params: dict[str, object]) -> pd.DataFrame:
+    lhs = str(params["lhs"])
+    rhs = str(params["rhs"])
+    tol = float(params.get("tol", 0.0))
+    diff = (frame[lhs] - frame[rhs]).abs()
+    mask = diff > tol
+    return frame.loc[mask, [lhs, rhs]]
+
+
+def functional_dependency(frame: pd.DataFrame, params: dict[str, object]) -> pd.DataFrame:
+    lhs = [str(col) for col in params.get("lhs", [])]
+    rhs = [str(col) for col in params.get("rhs", [])]
+    if not lhs or not rhs:
+        return frame.iloc[0:0]
+    dupes = frame.groupby(lhs, dropna=False)[rhs].nunique(dropna=False)
+    mask = (dupes > 1).any(axis=1)
+    if not mask.any():
+        return frame.iloc[0:0]
+    violating_keys = dupes[mask].index
+    merged = frame.set_index(lhs, drop=False)
+    return merged.loc[violating_keys].reset_index(drop=True)[lhs + rhs]
+
+
+TABLE_CHECKS: Dict[str, TableCheck] = {
+    "start_le_end": start_le_end,
+    "non_decreasing_by_key": non_decreasing_by_key,
+    "within_tolerance": within_tolerance,
+    "functional_dependency": functional_dependency,
+}

--- a/df_contracts/cli.py
+++ b/df_contracts/cli.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from .api import compare, is_breaking_change, validate
+from .inference import infer_contract
+from .report import ValidationReport
+from .schema import Contract, load_contract, save_contract
+from .utils import read_dataframe
+
+app = typer.Typer(help="DataFrame contract utilities")
+
+
+class CLIState:
+    def __init__(self) -> None:
+        self.contract: Contract | None = None
+        self.source: Path | None = None
+
+
+@app.callback()
+def main(ctx: typer.Context) -> None:
+    if ctx.obj is None:
+        ctx.obj = CLIState()
+
+
+@app.command()
+def init(
+    path: Path,
+    name: str = typer.Option("dataset", help="Contract name"),
+    version: str = typer.Option("0.1.0", help="Contract version"),
+    sample: Optional[float] = typer.Option(None, help="Sample fraction"),
+) -> None:
+    df = read_dataframe(path, sample=sample)
+    contract = infer_contract(df, name=name, version=version)
+    ctx: CLIState = typer.get_current_context().obj
+    ctx.contract = contract
+    ctx.source = path
+    typer.echo(contract.to_json())
+
+
+@app.command()
+def save(
+    out: Path = typer.Option(..., exists=False, help="Output contract file"),
+    format: Optional[str] = typer.Option(None, "--format", "-f", help="Force format json|toml"),
+    contract_path: Optional[Path] = typer.Option(None, help="Contract to load instead of last inferred"),
+) -> None:
+    ctx: CLIState = typer.get_current_context().obj
+    contract = ctx.contract if contract_path is None else load_contract(contract_path)
+    if contract is None:
+        raise typer.BadParameter("No contract available. Run init or provide --contract.")
+    if format:
+        fmt = format.lower()
+        if fmt == "json":
+            out.write_text(contract.to_json())
+            return
+        if fmt == "toml":
+            out.write_text(contract.to_toml())
+            return
+        raise typer.BadParameter("format must be 'json' or 'toml'")
+    save_contract(contract, out)
+
+
+@app.command()
+def check(
+    path: Path,
+    contract: Path = typer.Option(..., help="Contract file"),
+    profile: str = typer.Option("prod", help="Profile name"),
+    report: Optional[Path] = typer.Option(None, help="Optional JSON report output"),
+    sample: Optional[float] = typer.Option(None, help="Sample fraction"),
+    max_examples: int = typer.Option(20, help="Maximum examples in the report"),
+) -> None:
+    df = read_dataframe(path, sample=sample)
+    contract_obj = load_contract(contract)
+    validation = validate(df, contract_obj, profile=profile, max_examples=max_examples)
+    _render_report(validation)
+    if report:
+        report.write_text(validation.to_json())
+    raise typer.Exit(code=0 if validation.ok else 1)
+
+
+@app.command()
+def diff(old: Path, new: Path) -> None:
+    old_contract = load_contract(old)
+    new_contract = load_contract(new)
+    diff_result = compare(old_contract, new_contract)
+    console = Console()
+    console.print_json(data=diff_result)
+    if is_breaking_change(diff_result):
+        console.print("[bold red]Breaking changes detected[/bold red]")
+
+
+@app.command()
+def stats(path: Path, sample: Optional[float] = typer.Option(None, help="Sample fraction")) -> None:
+    df = read_dataframe(path, sample=sample)
+    table = Table(title="DataFrame Stats")
+    table.add_column("Column")
+    table.add_column("Dtype")
+    table.add_column("Null %", justify="right")
+    table.add_column("Distinct", justify="right")
+    for column in df.columns:
+        series = df[column]
+        null_ratio = series.isna().mean() * 100
+        distinct = series.nunique(dropna=True)
+        table.add_row(column, str(series.dtype), f"{null_ratio:.2f}", str(distinct))
+    Console().print(table)
+
+
+def _render_report(report: ValidationReport) -> None:
+    console = Console()
+    report.to_rich_console(console=console)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/df_contracts/errors.py
+++ b/df_contracts/errors.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+
+class DFContractsError(Exception):
+    """Base exception for df-contracts."""
+
+
+class ContractIOError(DFContractsError):
+    """Raised when contract files cannot be loaded or saved."""
+
+
+class SchemaValidationError(DFContractsError):
+    """Raised when a DataFrame violates the declared schema."""
+
+
+class RuleExecutionError(DFContractsError):
+    """Raised when a rule cannot be executed."""

--- a/df_contracts/inference.py
+++ b/df_contracts/inference.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import List
+
+import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype, is_numeric_dtype
+
+from .schema import ColumnSpec, Contract
+from .utils import ensure_pandas, normalize_dtype
+
+
+def _infer_datetime(series: pd.Series) -> bool:
+    if is_datetime64_any_dtype(series):
+        return True
+    converted = pd.to_datetime(series, errors="coerce")
+    success_ratio = converted.notna().mean()
+    if success_ratio >= 0.95:
+        series.update(converted)
+        return True
+    return False
+
+
+def infer_contract(
+    df: pd.DataFrame,
+    name: str,
+    version: str = "0.1.0",
+    *,
+    enum_max_cardinality: int = 50,
+    enum_min_freq_ratio: float = 0.95,
+    nullable_threshold: float = 0.0,
+) -> Contract:
+    frame = ensure_pandas(df)
+    columns: List[ColumnSpec] = []
+    for column in frame.columns:
+        series = frame[column]
+        series_no_na = series.dropna()
+        dtype = normalize_dtype(series.dtype)
+        if dtype == "object" and _infer_datetime(series):
+            dtype = normalize_dtype(series.dtype)
+        null_ratio = float(series.isna().mean())
+        if null_ratio == 0:
+            nullable: bool | float = False
+        elif null_ratio <= nullable_threshold:
+            nullable = False
+        else:
+            nullable = round(null_ratio, 4)
+        spec = ColumnSpec(name=column, dtype=dtype, nullable=nullable)
+        if is_numeric_dtype(series):
+            if not series_no_na.empty:
+                spec.min = series_no_na.min()
+                spec.max = series_no_na.max()
+        elif dtype.startswith("datetime64"):
+            if not series_no_na.empty:
+                spec.min = series_no_na.min().isoformat()
+                spec.max = series_no_na.max().isoformat()
+        if not series_no_na.empty and series_no_na.nunique() <= enum_max_cardinality:
+            coverage = float(series_no_na.value_counts(normalize=True).sum())
+            if coverage >= enum_min_freq_ratio:
+                spec.enum = sorted(series_no_na.astype(str).unique().tolist())
+        if series_no_na.is_unique and series.is_unique:
+            spec.unique = True
+        columns.append(spec)
+    unique_keys: list[list[str]] = []
+    return Contract(name=name, version=version, columns=columns, unique_keys=unique_keys)

--- a/df_contracts/plugin.py
+++ b/df_contracts/plugin.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+import orjson
+import pandas as pd
+import pytest
+
+from .api import validate
+from .report import ValidationReport
+from .schema import Contract, load_contract
+from .utils import ensure_pandas
+
+
+class PluginState:
+    def __init__(self, report_path: Path | None) -> None:
+        self.report_path = report_path
+        self.runs: list[dict[str, Any]] = []
+
+    def record(self, name: str, report: ValidationReport) -> None:
+        self.runs.append({"name": name, "report": report.as_dict()})
+
+    def write(self, path: Path | None = None) -> None:
+        target = path or self.report_path
+        if not target or not self.runs:
+            return
+        payload = {"runs": self.runs}
+        target.write_text(orjson.dumps(payload, option=orjson.OPT_INDENT_2).decode())
+
+
+class ContractsHelper:
+    def __init__(self, state: PluginState) -> None:
+        self._state = state
+
+    def load(self, contract_or_path: Contract | str | Path) -> Contract:
+        if isinstance(contract_or_path, Contract):
+            return contract_or_path
+        return load_contract(contract_or_path)
+
+    def must_match(
+        self,
+        contract_or_path: Contract | str | Path,
+        df: pd.DataFrame | Iterable[dict[str, Any]],
+        *,
+        profile: str = "prod",
+        max_examples: int = 20,
+    ) -> ValidationReport:
+        contract = self.load(contract_or_path)
+        if isinstance(df, pd.DataFrame):
+            frame = df
+        else:
+            frame = pd.DataFrame(list(df))
+        frame = ensure_pandas(frame)
+        report = validate(frame, contract, profile=profile, max_examples=max_examples)
+        self._state.record(contract.name, report)
+        if not report.ok:
+            raise AssertionError(
+                "DataFrame did not satisfy contract:\n" + report.to_json()
+            )
+        return report
+
+    def write_report(self, path: Path) -> None:
+        self._state.write(path)
+
+
+@pytest.fixture
+def df_contracts(request: pytest.FixtureRequest) -> ContractsHelper:
+    state: PluginState = request.config._dfc_state  # type: ignore[attr-defined]
+    return ContractsHelper(state)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption("--dfc-report", action="store", default=None, help="Aggregate report path")
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    report_opt = config.getoption("--dfc-report")
+    report_path = Path(report_opt) if report_opt else None
+    config._dfc_state = PluginState(report_path)  # type: ignore[attr-defined]
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    state: PluginState | None = getattr(config, "_dfc_state", None)
+    if state is not None:
+        state.write()

--- a/df_contracts/report.py
+++ b/df_contracts/report.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import orjson
+from rich.console import Console
+from rich.table import Table
+
+from .types import ValidationStats, ViolationDict
+
+
+@dataclass(slots=True)
+class ValidationReport:
+    ok: bool
+    stats: ValidationStats
+    violations: list[ViolationDict]
+    schema_diffs: list[str]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "stats": dict(self.stats),
+            "violations": [dict(v) for v in self.violations],
+            "schema_diffs": list(self.schema_diffs),
+        }
+
+    def to_json(self) -> str:
+        return orjson.dumps(self.as_dict(), option=orjson.OPT_INDENT_2).decode()
+
+    def to_rich_console(self, console: Console | None = None) -> None:
+        console = console or Console()
+        header = "VALIDATION PASSED" if self.ok else "VALIDATION FAILED"
+        console.rule(header)
+        console.print(f"Rows: {self.stats['rows']}  Columns: {self.stats['cols']}")
+        if self.schema_diffs:
+            console.print("[bold red]Schema differences:[/bold red]")
+            for diff in self.schema_diffs:
+                console.print(f"- {diff}")
+        if not self.violations:
+            console.print("No violations detected.")
+            return
+        table = Table(title="Violations")
+        table.add_column("ID")
+        table.add_column("Level")
+        table.add_column("Kind")
+        table.add_column("Columns")
+        table.add_column("Summary")
+        table.add_column("Count", justify="right")
+        for violation in self.violations:
+            table.add_row(
+                violation["id"],
+                violation["level"],
+                violation["kind"],
+                ", ".join(violation["columns"]),
+                violation["summary"],
+                str(violation["count"]),
+            )
+        console.print(table)

--- a/df_contracts/schema.py
+++ b/df_contracts/schema.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import orjson
+from pydantic import BaseModel, ConfigDict, Field
+from tomli import loads as load_toml
+from tomli_w import dumps as dump_toml
+
+from .errors import ContractIOError
+
+
+class ColumnSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    dtype: str
+    nullable: bool | float = False
+    unique: bool | list[str] | None = None
+    min: Optional[str | float | int] = None
+    max: Optional[str | float | int] = None
+    enum: Optional[list[str]] = None
+    allow_unknown: bool = False
+    regex: Optional[str] = None
+    min_length: Optional[int] = None
+    max_length: Optional[int] = None
+    tz: Optional[str] = None
+    description: Optional[str] = None
+    unit: Optional[str] = None
+
+
+class RuleSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    level: str = Field(pattern=r"^(ERROR|WARN)$")
+    kind: str = Field(pattern=r"^(row|table)$")
+    expr: Optional[str] = None
+    fn_name: Optional[str] = None
+    params: Dict[str, Any] = Field(default_factory=dict)
+    message: str
+
+
+class ProfileConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    max_null_ratio_multiplier: Optional[float] = None
+    max_examples: Optional[int] = None
+
+
+class Contract(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    version: str
+    description: Optional[str] = None
+    columns: List[ColumnSpec]
+    rules: List[RuleSpec] = Field(default_factory=list)
+    profile_defaults: Optional[Dict[str, ProfileConfig]] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    unique_keys: List[List[str]] = Field(default_factory=list)
+    allow_extra_columns: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump()
+
+    def to_json(self) -> str:
+        return orjson.dumps(self.to_dict(), option=orjson.OPT_INDENT_2).decode()
+
+    def to_toml(self) -> str:
+        return dump_toml(self.to_dict())
+
+    def column_map(self) -> dict[str, ColumnSpec]:
+        return {col.name: col for col in self.columns}
+
+
+def load_contract(path: str | Path) -> Contract:
+    file_path = Path(path)
+    try:
+        text = file_path.read_text()
+    except OSError as exc:  # pragma: no cover - IO errors
+        raise ContractIOError(str(exc)) from exc
+    if file_path.suffix.lower() == ".json":
+        data = orjson.loads(text)
+    elif file_path.suffix.lower() == ".toml":
+        data = load_toml(text)
+    else:  # pragma: no cover - invalid extensions
+        raise ContractIOError(f"Unsupported contract extension: {file_path.suffix}")
+    return Contract.model_validate(data)
+
+
+def save_contract(contract: Contract, path: str | Path) -> None:
+    file_path = Path(path)
+    if file_path.suffix.lower() == ".json":
+        payload = contract.to_json()
+    elif file_path.suffix.lower() == ".toml":
+        payload = contract.to_toml()
+    else:  # pragma: no cover - invalid extension
+        raise ContractIOError(f"Unsupported contract extension: {file_path.suffix}")
+    file_path.write_text(payload)

--- a/df_contracts/types.py
+++ b/df_contracts/types.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+
+class ValidationStats(TypedDict):
+    rows: int
+    cols: int
+    duration_ms: int
+
+
+class ViolationDict(TypedDict):
+    id: str
+    level: Literal["ERROR", "WARN"]
+    kind: Literal["column", "row", "table", "schema"]
+    columns: list[str]
+    summary: str
+    count: int
+    examples: list[dict[str, Any]]

--- a/df_contracts/utils.py
+++ b/df_contracts/utils.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+import warnings
+
+import pandas as pd
+from pandas.api.types import pandas_dtype
+
+try:  # pragma: no cover - optional dependency
+    import polars as pl
+except Exception:  # pragma: no cover
+    pl = None  # type: ignore[assignment]
+
+
+def ensure_pandas(df: Any) -> pd.DataFrame:
+    """Return a pandas DataFrame, converting from polars when necessary."""
+
+    if isinstance(df, pd.DataFrame):
+        return df
+    if pl is not None and isinstance(df, pl.DataFrame):  # pragma: no cover - optional
+        warnings.warn("Converting polars.DataFrame to pandas.DataFrame", stacklevel=2)
+        return df.to_pandas()
+    raise TypeError("df_contracts.validate expects a pandas or polars DataFrame")
+
+
+def normalize_dtype(dtype: Any) -> str:
+    """Normalise dtype representation to a stable pandas string."""
+
+    try:
+        pd_dtype = pandas_dtype(dtype)
+    except TypeError:
+        return str(dtype)
+    return str(pd_dtype)
+
+
+def is_dtype_compatible(actual: str, expected: str) -> bool:
+    actual_norm = normalize_dtype(actual).lower()
+    expected_norm = normalize_dtype(expected).lower()
+    if actual_norm == expected_norm:
+        return True
+    numeric_aliases = {
+        "int64": {"int64", "int32", "int16", "int8", "int"},
+        "float64": {"float64", "float32", "float", "double"},
+        "bool": {"bool", "boolean"},
+        "boolean": {"bool", "boolean"},
+        "string": {"string", "object"},
+    }
+    for aliases in numeric_aliases.values():
+        if expected_norm in aliases and actual_norm in aliases:
+            return True
+    if expected_norm.startswith("datetime64") and actual_norm.startswith("datetime64"):
+        return True
+    return False
+
+
+def read_dataframe(path: str | Path, *, sample: float | None = None) -> pd.DataFrame:
+    path = Path(path)
+    suffix = path.suffix.lower()
+    if suffix in {".csv", ".tsv", ".txt"}:
+        df = pd.read_csv(path)
+    elif suffix in {".parquet"}:
+        df = pd.read_parquet(path)
+    else:
+        raise ValueError(f"Unsupported file extension: {path.suffix}")
+    if sample:
+        if not 0 < sample <= 1:
+            raise ValueError("sample must be in (0, 1]")
+        df = df.sample(frac=sample, random_state=0)
+    return df
+
+
+def head_records(frame: pd.DataFrame, *, limit: int) -> list[dict[str, Any]]:
+    limited = frame.head(limit)
+    return [row._asdict() for row in limited.itertuples(index=False, name="Row")]
+
+
+__all__ = [
+    "ensure_pandas",
+    "normalize_dtype",
+    "is_dtype_compatible",
+    "read_dataframe",
+    "head_records",
+]

--- a/df_contracts/versioning.py
+++ b/df_contracts/versioning.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .schema import Contract
+from .utils import normalize_dtype
+
+
+def _describe(message: str, *, column: str | None = None) -> str:
+    return f"{column}: {message}" if column else message
+
+
+def compare_contracts(old: Contract, new: Contract) -> dict[str, Any]:
+    breaking: List[str] = []
+    non_breaking: List[str] = []
+    changed_columns: Dict[str, dict[str, Any]] = {}
+    old_cols = {col.name: col for col in old.columns}
+    new_cols = {col.name: col for col in new.columns}
+    for name, old_col in old_cols.items():
+        if name not in new_cols:
+            breaking.append(_describe("column removed", column=name))
+            continue
+        new_col = new_cols[name]
+        col_changes: dict[str, Any] = {}
+        if normalize_dtype(old_col.dtype) != normalize_dtype(new_col.dtype):
+            col_changes["dtype"] = {"from": old_col.dtype, "to": new_col.dtype}
+            if _is_dtype_narrowing(old_col.dtype, new_col.dtype):
+                breaking.append(_describe("dtype narrowed", column=name))
+            else:
+                non_breaking.append(_describe("dtype widened", column=name))
+        old_nullable = old_col.nullable
+        new_nullable = new_col.nullable
+        if old_nullable != new_nullable:
+            col_changes["nullable"] = {"from": old_nullable, "to": new_nullable}
+            if _nullable_stricter(old_nullable, new_nullable):
+                breaking.append(_describe("nullability tightened", column=name))
+            else:
+                non_breaking.append(_describe("nullability relaxed", column=name))
+        if old_col.enum and new_col.enum:
+            old_enum = set(old_col.enum)
+            new_enum = set(new_col.enum)
+            removed = sorted(old_enum - new_enum)
+            added = sorted(new_enum - old_enum)
+            if removed:
+                breaking.append(_describe(f"enum removed values {removed}", column=name))
+            if added:
+                non_breaking.append(_describe(f"enum added values {added}", column=name))
+            if removed or added:
+                col_changes["enum"] = {"removed": removed, "added": added}
+        if col_changes:
+            changed_columns[name] = col_changes
+    for name in new_cols.keys() - old_cols.keys():
+        non_breaking.append(_describe("column added", column=name))
+    rule_changes: dict[str, Any] = {}
+    old_rules = {rule.id: rule for rule in old.rules}
+    new_rules = {rule.id: rule for rule in new.rules}
+    for rule_id, old_rule in old_rules.items():
+        if rule_id not in new_rules:
+            breaking.append(f"rule {rule_id} removed")
+            continue
+        new_rule = new_rules[rule_id]
+        if old_rule.level != new_rule.level or old_rule.kind != new_rule.kind or old_rule.message != new_rule.message:
+            rule_changes[rule_id] = {
+                "from": old_rule.model_dump(),
+                "to": new_rule.model_dump(),
+            }
+            if new_rule.level == "ERROR" and old_rule.level == "WARN":
+                breaking.append(f"rule {rule_id} escalated to ERROR")
+    for rule_id in new_rules.keys() - old_rules.keys():
+        new_rule = new_rules[rule_id]
+        impact = "breaking" if new_rule.level == "ERROR" else "non-breaking"
+        (breaking if impact == "breaking" else non_breaking).append(f"rule {rule_id} added")
+    return {
+        "breaking": breaking,
+        "non_breaking": non_breaking,
+        "changed_columns": changed_columns,
+        "changed_rules": rule_changes,
+    }
+
+
+def _is_dtype_narrowing(old: str, new: str) -> bool:
+    old_norm = normalize_dtype(old)
+    new_norm = normalize_dtype(new)
+    if old_norm == new_norm:
+        return False
+    numeric_order = ["int8", "int16", "int32", "int64", "float32", "float64"]
+    if old_norm in numeric_order and new_norm in numeric_order:
+        return numeric_order.index(new_norm) < numeric_order.index(old_norm)
+    if old_norm.startswith("float") and new_norm.startswith("int"):
+        return True
+    if old_norm.startswith("datetime64") and not new_norm.startswith("datetime64"):
+        return True
+    return True
+
+
+def _nullable_stricter(old: bool | float, new: bool | float) -> bool:
+    def to_ratio(value: bool | float) -> float:
+        if isinstance(value, bool):
+            return 1.0 if value else 0.0
+        return float(value)
+
+    return to_ratio(new) < to_ratio(old)
+
+
+def is_breaking_change(diff: dict[str, Any]) -> bool:
+    return bool(diff.get("breaking"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "df-contracts"
+version = "0.1.0"
+description = "Lightweight DataFrame contracts for pandas"
+readme = "README.md"
+authors = [{name = "OpenAI", email = "opensource@openai.com"}]
+license = {text = "MIT"}
+requires-python = ">=3.10"
+dependencies = [
+    "pandas",
+    "numpy",
+    "pydantic>=2",
+    "typer",
+    "rich",
+    "orjson",
+    "tomli-w",
+    "tomli",
+    "python-dateutil",
+    "regex",
+]
+optional-dependencies = { polars = ["polars"] }
+
+[project.urls]
+Homepage = "https://example.com/df-contracts"
+
+[project.scripts]
+dfc = "df_contracts.cli:app"
+
+[tool.black]
+line-length = 100
+target-version = ["py310"]
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "I", "B"]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+packages = ["df_contracts"]
+
+[tool.pytest.ini_options]
+addopts = "-ra --strict-markers"
+testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+source = ["df_contracts"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+pytest_plugins = ["df_contracts.plugin"]
+
+
+@pytest.fixture(scope="session")
+def sample_path() -> Path:
+    return Path("tests/data/sample.csv")
+
+
+@pytest.fixture(scope="session")
+def bad_sample_path() -> Path:
+    return Path("tests/data/bad_sample.csv")
+
+
+@pytest.fixture
+def sample_df(sample_path: Path) -> pd.DataFrame:
+    return pd.read_csv(sample_path)
+
+
+@pytest.fixture
+def bad_sample_df(bad_sample_path: Path) -> pd.DataFrame:
+    return pd.read_csv(bad_sample_path)

--- a/tests/data/bad_sample.csv
+++ b/tests/data/bad_sample.csv
@@ -1,0 +1,6 @@
+id,category,amount,email,start_date,end_date,ratio
+1,A,-10.0,alpha_at_example.com,2024-01-06,2024-01-02,
+3,C,200.0,beta@example.com,2024-01-04,2024-01-03,0.50
+3,A,150.2,gamma@example.com,2024-01-02,2024-01-01,0.40
+4,B,180.1,delta@example.com,2024-01-05,2024-01-05,0.18
+5,A,220.7,epsilon@example.com,2024-01-06,2024-01-10,0.25

--- a/tests/data/sample.csv
+++ b/tests/data/sample.csv
@@ -1,0 +1,6 @@
+id,category,amount,email,start_date,end_date,ratio
+1,A,100.5,alpha@example.com,2024-01-01,2024-01-05,0.10
+2,B,200.0,beta@example.com,2024-01-03,2024-01-04,0.20
+3,A,150.2,gamma@example.com,2024-01-02,2024-01-08,0.15
+4,B,180.1,delta@example.com,2024-01-05,2024-01-05,0.18
+5,A,220.7,epsilon@example.com,2024-01-06,2024-01-10,0.25

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from df_contracts import RuleSpec, infer_contract, validate
+
+
+def _augment_contract(contract):
+    columns = {col.name: col for col in contract.columns}
+    columns["amount"].min = 0
+    columns["email"].regex = r"^[^@]+@[^@]+\\.[^@]+$"
+    columns["id"].unique = True
+    columns["category"].allow_unknown = False
+    columns["ratio"].max = 1
+    return contract
+
+
+def test_validate_pass(sample_df):
+    contract = infer_contract(sample_df, name="orders")
+    contract = _augment_contract(contract)
+    contract.rules.append(
+        RuleSpec(
+            id="amount_positive",
+            level="ERROR",
+            kind="row",
+            expr="amount >= 0",
+            message="amount must be non-negative",
+        )
+    )
+    contract.rules.append(
+        RuleSpec(
+            id="start_before_end",
+            level="ERROR",
+            kind="table",
+            fn_name="start_le_end",
+            params={"start": "start_date", "end": "end_date"},
+            message="start must be <= end",
+        )
+    )
+    report = validate(sample_df, contract)
+    assert report.ok
+    assert report.violations == []
+
+
+def test_validate_failures(sample_df):
+    contract = infer_contract(sample_df, name="orders")
+    contract = _augment_contract(contract)
+    contract.rules.append(
+        RuleSpec(
+            id="amount_positive",
+            level="ERROR",
+            kind="row",
+            expr="amount >= 0",
+            message="amount must be non-negative",
+        )
+    )
+    contract.rules.append(
+        RuleSpec(
+            id="start_before_end",
+            level="ERROR",
+            kind="table",
+            fn_name="start_le_end",
+            params={"start": "start_date", "end": "end_date"},
+            message="start must be <= end",
+        )
+    )
+    broken = sample_df.copy()
+    broken.loc[0, "category"] = "C"
+    broken.loc[1, "email"] = "not-an-email"
+    broken.loc[2, "amount"] = -10
+    broken.loc[3, "id"] = 1
+    broken.loc[4, "start_date"] = pd.Timestamp("2024-01-11")
+    report = validate(broken, contract)
+    assert not report.ok
+    violation_ids = {violation["id"] for violation in report.violations}
+    assert "column.category.enum" in violation_ids
+    assert "column.email.regex" in violation_ids
+    assert "column.amount.min" in violation_ids
+    assert "column.id.unique" in violation_ids
+    assert "rule.start_before_end" in violation_ids

--- a/tests/test_cli_init_check.py
+++ b/tests/test_cli_init_check.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "df_contracts.cli", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_init_and_check(tmp_path: Path, sample_path: Path, bad_sample_path: Path) -> None:
+    result = run_cli("init", str(sample_path))
+    assert result.returncode == 0, result.stderr
+    contract_file = tmp_path / "contract.json"
+    contract_file.write_text(result.stdout)
+
+    check_ok = run_cli(
+        "check",
+        str(sample_path),
+        "--contract",
+        str(contract_file),
+    )
+    assert check_ok.returncode == 0, check_ok.stderr
+
+    report_file = tmp_path / "report.json"
+    check_bad = run_cli(
+        "check",
+        str(bad_sample_path),
+        "--contract",
+        str(contract_file),
+        "--report",
+        str(report_file),
+    )
+    assert check_bad.returncode != 0
+    payload = json.loads(report_file.read_text())
+    assert payload["violations"]

--- a/tests/test_infer_and_upgrade.py
+++ b/tests/test_infer_and_upgrade.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from df_contracts import compare, infer_contract, is_breaking_change
+
+
+def test_infer_and_breaking_change(sample_df):
+    old = infer_contract(sample_df, name="orders", version="0.1.0")
+    new = infer_contract(sample_df, name="orders", version="0.2.0")
+    columns = {col.name: col for col in new.columns}
+    columns["amount"].dtype = "int64"
+    diff = compare(old, new)
+    assert is_breaking_change(diff)
+    assert any("dtype" in change for change in diff["breaking"])

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from df_contracts import RuleSpec, infer_contract
+
+
+def build_contract(df: pd.DataFrame):
+    contract = infer_contract(df, name="orders")
+    columns = {col.name: col for col in contract.columns}
+    columns["amount"].min = 0
+    columns["id"].unique = True
+    contract.rules.append(
+        RuleSpec(
+            id="amount_positive",
+            level="ERROR",
+            kind="row",
+            expr="amount >= 0",
+            message="amount must be non-negative",
+        )
+    )
+    return contract
+
+
+def test_plugin_must_match(sample_df: pd.DataFrame, tmp_path: Path, df_contracts) -> None:
+    contract = build_contract(sample_df)
+    df_contracts.must_match(contract, sample_df)
+    broken = sample_df.copy()
+    broken.loc[0, "amount"] = -1
+    with pytest.raises(AssertionError):
+        df_contracts.must_match(contract, broken)
+    report_path = tmp_path / "agg.json"
+    df_contracts.write_report(report_path)
+    payload = json.loads(report_path.read_text())
+    assert payload["runs"]


### PR DESCRIPTION
## Summary
- implement the df_contracts package including schema models, validation engine, inference, reporting, CLI, pytest plugin, and versioning helpers
- add project configuration such as pyproject metadata, tooling configs, CI workflow, and documentation
- provide comprehensive automated tests and sample data covering API validation, CLI usage, pytest plugin behaviour, and contract diffing

## Testing
- pytest *(fails: pandas dependency unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de5098609c833193ce4025363486ff